### PR TITLE
Settings default center

### DIFF
--- a/components/src/components/Map/Component.ts
+++ b/components/src/components/Map/Component.ts
@@ -4,7 +4,9 @@ import MapService from './services/MapService';
 import baseEditForm from './Component.form';
 import * as L from 'leaflet';
 
-const CENTER: [number, number] = [48.41939025932759, -123.37029576301576]; // Ensure CENTER is a tuple with exactly two elements
+const DEFAULT_CENTER: [number, number] = [
+  48.41939025932759, -123.37029576301576,
+]; // Ensure CENTER is a tuple with exactly two elements
 
 export default class Component extends (FieldComponent as any) {
   static schema(...extend) {
@@ -69,11 +71,17 @@ export default class Component extends (FieldComponent as any) {
       drawOptions[this.component.markerType] = true; // set marker type from user choice
     }
 
-    const { numPoints, defaultZoom, readOnlyMap } = this.component;
+    const { numPoints, defaultZoom, readOnlyMap, center } = this.component;
+
+    let parsedCenter;
+    if (center) {
+      parsedCenter = JSON.parse(center).latlng;
+    }
+
     this.mapService = new MapService({
       mapContainer,
       drawOptions,
-      center: CENTER,
+      center: center ? parsedCenter : DEFAULT_CENTER,
       form,
       numPoints,
       defaultZoom,

--- a/components/src/components/Map/editForm/Component.edit.data.ts
+++ b/components/src/components/Map/editForm/Component.edit.data.ts
@@ -57,6 +57,19 @@ export default {
       input: true,
     },
     {
+      key: 'center',
+      type: 'map',
+      input: true,
+      label: 'Default Center',
+      numPoints: 1,
+      tableView: false,
+      markerType: 'marker',
+      defaultZoom: 13,
+      readOnlyMap: false,
+      description:
+        'Please select the desired default center using a single marker',
+    },
+    {
       label: 'Read Only Map',
       description:
         'This allows for the user to view and scroll the map, but not add any input',

--- a/components/src/components/Map/editForm/Component.edit.data.ts
+++ b/components/src/components/Map/editForm/Component.edit.data.ts
@@ -1,57 +1,67 @@
 import common from '../../Common/Simple.edit.data';
-export default
+export default {
+  key: 'data',
+  components: [
+    ...common,
     {
-        key: 'data',
-        components: [
-            ...common,
-            {
-                label: "Marker Type ",
-                values: [
-                    {
-                        label: "Point Marker",
-                        value: "marker"
-                    },
-                    {
-                        label: "Circle",
-                        value: "circle",
-                    }
-                ],
-                defaultValue: "marker",
-                key: "markerType",
-                type: "simpleradios",
-                input: true,
-            },
-            {
-                label: "How many Points per Submission?",
-                key: "numPoints",
-                type: "simplenumber",
-                defaultValue: 1,
-                input: true,
-            },
+      label: 'Marker Type ',
+      values: [
+        {
+          label: 'Point Marker',
+          value: 'marker',
+        },
+        {
+          label: 'Circle',
+          value: 'circle',
+        },
+      ],
+      defaultValue: 'marker',
+      key: 'markerType',
+      type: 'simpleradios',
+      input: true,
+    },
+    {
+      label: 'Set Default Center',
+      tableView: false,
+      markerType: 'marker',
+      numPoints: 1,
+      defaultZoom: 5,
+      readOnlyMap: false,
+      key: 'map',
+      type: 'map',
+      input: true,
+    },
+    {
+      label: 'How many Points per Submission?',
+      key: 'numPoints',
+      type: 'simplenumber',
+      defaultValue: 1,
+      input: true,
+    },
 
-            {
-                label: "Default Zoom Level",
-                description: "Zoom Levels are from 0 (Most zoomed out) to 18 (most zoomed in).",
-                defaultValue: 13,
-                delimiter: false,
-                requireDecimal: false,
-                validate: {
-                    isUseForCopy: false,
-                    min: 0,
-                    max: 18
-                },
-                key: "defaultZoom",
-                type: "simplenumber",
-                input: true,
-            },
-            {
-                label: "Read Only Map",
-                description: "This allows for the user to view and scroll the map, but not add any input",
-                key: "readOnlyMap",
-                type: "simplecheckbox",
-                input: true,
-
-            }
-        ]
-    }
-
+    {
+      label: 'Default Zoom Level',
+      description:
+        'Zoom Levels are from 0 (Most zoomed out) to 18 (most zoomed in).',
+      defaultValue: 13,
+      delimiter: false,
+      requireDecimal: false,
+      validate: {
+        isUseForCopy: false,
+        min: 0,
+        max: 18,
+      },
+      key: 'defaultZoom',
+      type: 'simplenumber',
+      input: true,
+    },
+    {
+      label: 'Read Only Map',
+      description:
+        'This allows for the user to view and scroll the map, but not add any input',
+      key: 'readOnlyMap',
+      type: 'simplecheckbox',
+      input: true,
+    },
+  ],
+};


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

I have added a new field in the map settings for setting a default center of the map to the form designer's choosing.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- Uncomment the main reason for the change (for example, all feat PRs should include docs and test, but only uncomment feat): -->

 feat (a new feature)
