### PR TITLE
Fix map broken in Map Settings Page 

### DIFF
--- a/components/src/components/Map/Component.ts
+++ b/components/src/components/Map/Component.ts
@@ -75,18 +75,19 @@ export default class Component extends (FieldComponent as any) {
     const { numPoints, defaultZoom, readOnlyMap, center, defaultValue } =
       this.component;
 
-
     const { readOnly: viewMode } = this.options;
 
     let initialCenter;
     if (center && center.features && center.features[0]) {
       initialCenter = center.features[0].coordinates;
+    } else {
+      initialCenter = DEFAULT_CENTER;
     }
 
     this.mapService = new MapService({
       mapContainer,
       drawOptions,
-      center: center ? initialCenter : DEFAULT_CENTER,
+      center: initialCenter,
       form,
       numPoints,
       defaultZoom,

--- a/components/src/components/Map/services/MapService.ts
+++ b/components/src/components/Map/services/MapService.ts
@@ -26,6 +26,7 @@ class MapService {
   options;
   map;
   drawnItems;
+
   constructor(options) {
     this.options = options;
 
@@ -33,7 +34,10 @@ class MapService {
       const { map, drawnItems } = this.initializeMap(options);
       this.map = map;
       this.drawnItems = drawnItems;
+
       map.invalidateSize();
+      // Triggering a resize event after map initialization
+      setTimeout(() => window.dispatchEvent(new Event('resize')), 0);
       // Event listener for drawn objects
       map.on('draw:created', (e) => {
         let layer = e.layer;
@@ -54,6 +58,10 @@ class MapService {
       map.on(L.Draw.Event.EDITED, (e) => {
         options.onDrawnItemsChange(drawnItems.getLayers());
       });
+
+      map.on('resize', () => {
+        map.invalidateSize();
+      });
     }
   }
 
@@ -68,10 +76,10 @@ class MapService {
       viewMode,
     } = options;
 
-
     if (drawOptions.rectangle) {
       drawOptions.rectangle.showArea = false;
     }
+
     const map = L.map(mapContainer).setView(
       center,
       defaultZoom || DEFAULT_MAP_ZOOM
@@ -79,11 +87,12 @@ class MapService {
     L.tileLayer(DEFAULT_MAP_LAYER_URL, {
       attribution: DEFAULT_LAYER_ATTRIBUTION,
     }).addTo(map);
+
     // Initialize Draw Layer
     let drawnItems = new L.FeatureGroup();
     map.addLayer(drawnItems);
-    // Add Drawing Controllers
 
+    // Add Drawing Controllers
     if (!readOnlyMap) {
       if (!viewMode) {
         let drawControl = new L.Control.Draw({
@@ -95,6 +104,7 @@ class MapService {
         map.addControl(drawControl);
       }
     }
+
     // Checking to see if the map should be interactable
     const componentEditNode =
       document.getElementsByClassName(COMPONENT_EDIT_CLASS);
@@ -111,6 +121,7 @@ class MapService {
     }
     return { map, drawnItems };
   }
+
   bindPopupToLayer(layer) {
     if (layer instanceof L.Marker) {
       layer
@@ -140,6 +151,7 @@ class MapService {
         .openPopup();
     }
   }
+
   loadDrawnItems(items) {
     const { drawnItems } = this;
     if (!drawnItems) {
@@ -169,6 +181,7 @@ class MapService {
       }
     });
   }
+
   hasChildNode(parent, targetNode) {
     if (parent === targetNode) {
       return true;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
Fix map broken in Map Settings Page  data Section for data Center and data Default Map


<!-- Describe your changes in detail -->
Why is this change required? What problem does it solve? 
IT fixes the bug with Map Designer setting Map Rendering Issue.
Before:
![image](https://github.com/user-attachments/assets/43381d4d-74fe-4d47-b2f2-9b61bc5b7d06)

After Fix:
![image](https://github.com/user-attachments/assets/19910989-b2b9-4b41-853b-994c60320051)

If it fixes an open issue, please link to the issue here. 
https://bcdevex.atlassian.net/browse/FORMS-1373

## Types of changes

<!-- Uncomment the main reason for the change (for example, all feat PRs should include docs and test, but only uncomment feat): -->

<!-- feat (a new feature) -->
<!-- fix (a bug fix) -->

<!-- build (change in build system or dependencies) -->
<!-- ci (change in continuous integration / deployment) -->
<!-- docs (change to documentation) -->
<!-- perf (change to improve performance) -->
<!-- refactor (change to improve code quality) -->
<!-- style (change to code style/formatting) -->
<!-- test (add missing tests or correct existing tests) -->

<!--
This is a breaking change because ...
-->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](/bcgov/common-hosted-form-service/blob/main/CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have run the npm script lint on the frontend and backend
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have approval from the product owner for the contribution in this pull request

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
